### PR TITLE
feat: implement Shunting-Yard algorithm for RPN conversion

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from parser import clean_input, normalize_signs, tokenize
+from parser import clean_input, normalize_signs, tokenize, to_rpn
 
 def main():
     print("Advanced Mathematical Expression Evaluator (Python)")
@@ -15,22 +15,29 @@ def main():
             print("Please enter a valid expression.\n")
             continue
 
-        # مرحله ۱: پاک‌سازی
-        cleaned = clean_input(expr)
-        print(f"Cleaned:     {cleaned}")
-
-        # مرحله ۲: عادی‌سازی علامت‌ها
-        normalized = normalize_signs(cleaned)
-        print(f"Normalized:  {normalized}")
-
-        # مرحله ۳: توکنایزر
         try:
+            # مرحله ۱: پاک‌سازی
+            cleaned = clean_input(expr)
+            print(f"Cleaned:     {cleaned}")
+
+            # مرحله ۲: عادی‌سازی علامت‌ها
+            normalized = normalize_signs(cleaned)
+            print(f"Normalized:  {normalized}")
+
+            # مرحله ۳: توکنایزر
             tokens = tokenize(normalized)
             print(f"Tokens:      {tokens}")
-        except ValueError as e:
-            print(f"Tokenization Error: {e}")
 
-        print("-" * 60)
+            # مرحله ۴: تبدیل به RPN
+            rpn = to_rpn(tokens)
+            print(f"RPN:         {rpn}")
+
+        except ValueError as e:
+            print(f"Error: {e}")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+
+        print("-" * 70)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### feat/shunting-yard-rpn: Implement Reverse Polish Notation conversion

**Changes:**
- Added `precedence()` function with correct priorities (√ > ^ > */ > +-)
- Implemented full Shunting-Yard algorithm:
  - Proper handling of operator associativity (^ right, others left)
  - Correct unary √ handling
  - Parentheses support with mismatch detection
- Updated `main.py` to show RPN output
- Comprehensive error handling

**Verified Examples:**
- `√(4² + 3²)` → `[4, 2, '^', 3, 2, '^', '+', '√']`
- `2^3^2` → `[2, 3, 2, '^', '^']` ✓ (correct right-associativity)
- Complex nested expressions work perfectly

**Next Step:** Build expression tree from RPN